### PR TITLE
 [PI-126] New endpoint to filter used addresses 

### DIFF
--- a/src/db-api.js
+++ b/src/db-api.js
@@ -1,8 +1,21 @@
 /**
+ * Returns the list of addresses that were used at least once (as input or output)
+ * @param {Db Object} db
+ * @param {Array<Address>} addresses
+ */
+async function filterUsedAddresses(db, addresses) {
+  return db.query({
+    text: 'SELECT DISTINCT address FROM "tx_addresses" WHERE address = ANY($1)',
+    values: [addresses],
+    rowMode: 'array',
+  });
+}
+
+/**
  * Queries UTXO table looking for unspents for given addresses
  *
  * @param {Db Object} db
- * @param {Array[Address]} addresses
+ * @param {Array<Address>} addresses
  */
 async function utxoForAddresses(db, addresses) {
   return db.query('SELECT * FROM "utxos" WHERE receiver = ANY($1)', [
@@ -21,9 +34,15 @@ async function utxoSumForAddresses(db, addresses) {
  * for the given addresses
  *
  * @param {Db Object} db
- * @param {Array[Address]} addresses
+ * @param {Array<Address>} addresses
  */
-async function transactionsHistoryForAddresses(db, addresses, dateFrom, sort, limit = 20) {
+async function transactionsHistoryForAddresses(
+  db,
+  addresses,
+  dateFrom,
+  sort,
+  limit = 20,
+) {
   // We are using sort as string as it cannot be sent as parameter
   const timeSort = sort === 'ASC' || sort === 'DESC' ? sort : 'ASC';
   return db.query(
@@ -47,6 +66,7 @@ async function transactionsHistoryForAddresses(db, addresses, dateFrom, sort, li
 }
 
 module.exports = {
+  filterUsedAddresses,
   utxoForAddresses,
   utxoSumForAddresses,
   transactionsHistoryForAddresses,

--- a/src/routes.js
+++ b/src/routes.js
@@ -30,11 +30,11 @@ function validateDatetimeReq({ dateFrom } = {}) {
 
 /**
  * Validates order parameter sent in query string
- * @param {Object} Order 
+ * @param {Object} Order
  */
-function validateOrderReq({order} = {}) {
-  if(!order || (order !== 'ASC' && order !== 'DESC')) {
-    throw new Error('Order should be "ASC" or "DESC"'); 
+function validateOrderReq({ order } = {}) {
+  if (!order || (order !== 'ASC' && order !== 'DESC')) {
+    throw new Error('Order should be "ASC" or "DESC"');
   }
   return true;
 }
@@ -67,6 +67,26 @@ const utxoForAddresses = (db, { logger }) => async (req, res, next) => {
     return next();
   } catch (err) {
     logger.error('[utxoForAddresses] Error', err);
+    return next(err);
+  }
+};
+
+/**
+ * This endpoint filters the given addresses returning the ones that were
+ * used at least once
+ * @param {*} db Database
+ * @param {*} Server Server Config Object
+ */
+const filterUsedAddresses = (db, { logger }) => async (req, res, next) => {
+  try {
+    logger.debug('[filterUsedAddresses] request start');
+    validateAddressesReq(req.body);
+    const result = await dbApi.filterUsedAddresses(db, req.body.addresses);
+    res.send(result.rows.reduce((acc, row) => acc.concat(row), []));
+    logger.debug('[filterUsedAddresses] request end');
+    return next();
+  } catch (err) {
+    logger.error('[filterUsedAddresses] Error', err);
     return next(err);
   }
 };
@@ -163,6 +183,11 @@ module.exports = {
     method: 'get',
     path: withPrefix('/healthcheck'),
     handler: healthCheck,
+  },
+  filterUsedAddresses: {
+    method: 'post',
+    path: withPrefix('/addresses/filterUsed'),
+    handler: filterUsedAddresses,
   },
   utxoForAddresses: {
     method: 'post',


### PR DESCRIPTION
# Description

This new endpoint, given a list of addresses, returns a set of ones that were used at least once (to receive 

Route : `/addresses/filterUsed`

Body:
```javascript
{
  "addresses": Array<Address>,
}
```

**This method limits the response length to 20 addresses. It doesn't keep order (as it returns a set).**

Example:

```json
{
  "addresses": ["Ae2tdPwUPEZMobpYFKScvc2AW4ZjKYtEspkNXNA4R1uB6ZkKSa4GdKdJkib", "aaa"]
}
```

Response:

```json
[
    "Ae2tdPwUPEZMobpYFKScvc2AW4ZjKYtEspkNXNA4R1uB6ZkKSa4GdKdJkib"
]
```