### PR TITLE
[PI-137] Tx history query is changed so that it returns txs after the…

### DIFF
--- a/src/db-api.js
+++ b/src/db-api.js
@@ -57,7 +57,7 @@ async function transactionsHistoryForAddresses(
         where address = ANY ($1)
       )
       AND 
-        time >= $2
+        time > $2
     ORDER BY time ${timeSort}
     LIMIT ${limit}
    `,


### PR DESCRIPTION
The tx history query receives the date from the last transaction that the client has and so it should return all transactions after this one, without including it. 