### PR TITLE
Remove pm2 from the Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,5 @@
 FROM mhart/alpine-node:8.9.4
 
-RUN apk add --update bash bash-doc util-linux pciutils usbutils coreutils binutils findutils grep python make \ 
-    && npm install -g pm2 \
-    && pm2 install pm2-logrotate \ 
-    && pm2 set pm2-logrotate:max_size 500M \
-    && mkdir -p /usr/app
-
 WORKDIR /usr/app
 COPY ./ /usr/app
 
@@ -15,4 +9,5 @@ RUN cd /usr/app && npm install && npm run flow-remove-types &&  npm prune --prod
 
 WORKDIR /usr/app
 
-CMD ["pm2", "start", "./flow-files/index.js", "-i", "0", "--no-daemon"]
+CMD ["node", "./flow-files/index.js"]
+


### PR DESCRIPTION
This PR simply removes the `pm2` process manager from the backend Docker image. It is not needed for container-based deployments and is actually detrimental, as it hinders log collection.

This has been tested with the `docker-compose` setup in `input-output-hk/project-icarus`.