### PR TITLE
Dynamic deployment for importer endpoint

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -5,5 +5,8 @@
     "database": "DB",
     "password": "DB_PASSWORD",
     "port": "DB_PORT"
+  },
+  "server": {
+    "importerSendTxEndpoint": "IMPORTER_ENDPOINT"
   }
 }

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,18 +1,25 @@
 const { raw } = require('config/raw');
 const { consoleLogger } = require('../src/logger');
 
+var getEnv = function(name) {
+    var ret = process.env[name];
+    if (!ret)
+        throw ("Environment variables should be defined: " + name);
+    return ret;
+}
+
 module.exports = {
     server: {
         corsEnabledFor: ['*'],
-        logger: raw(consoleLogger('error')),
+        logger: raw(consoleLogger('info')),
         port: 8080,
-        importerSendTxEndpoint: 'fake',
+        importerSendTxEndpoint: getEnv("IMPORTER_ENDPOINT"),
     },
     db: {
-        user: 'fake',
-        host: 'fake',
-        database: 'fake',
-        password: 'fake',
+        user: getEnv("DB_USER"),
+        host: getEnv("DB_HOST"),
+        database: getEnv("DB"),
+        password: getEnv("DB_PASSWORD"),
         port: '5432',
         min: 4,
         max: 50,

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,0 +1,22 @@
+const { raw } = require('config/raw');
+const { consoleLogger } = require('../src/logger');
+
+module.exports = {
+    server: {
+        corsEnabledFor: ['*'],
+        logger: raw(consoleLogger('error')),
+        port: 8080,
+        importerSendTxEndpoint: 'fake',
+    },
+    db: {
+        user: 'fake',
+        host: 'fake',
+        database: 'fake',
+        password: 'fake',
+        port: '5432',
+        min: 4,
+        max: 50,
+        idleTimeoutMillis: 1000,
+        connectionTimeoutMillis: 5000,
+    },
+};


### PR DESCRIPTION
Based on #45 .

This PR makes it possible to dynamically configure the importer endpoint via the `$IMPORTER_ENDPOINT` environment variable.

It adds a `deploy` configuration to be used with this method.